### PR TITLE
Fix type error for the version option

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var exportObj = function(options) {
 			},
 
 			function(flushCb) {
-				if (options.version !== '') hasher.update(options.version);
+				if (options.version !== '') hasher.update(String(options.version));
 				file.hash = hasher.digest('hex').slice(0, options.hashLength);
 
 				file.origFilename = path.basename(file.relative);

--- a/test/algorithms.js
+++ b/test/algorithms.js
@@ -7,17 +7,31 @@ var path = require('path'),
 	hash = require('../index.js');
 
 describe('hash()', function() {
-	it('should append the hash to files with buffer content', function(done) {
-		gulp.src(__dirname + '/fixture.txt', {buffer: true})
+	it('should change the hash using given version (string)', function(done) {
+		gulp.src(__dirname + '/fixture.txt')
 			.pipe(hash({
 				algorithm: 'sha1',
-				hashLength: 8
+				hashLength: 8,
+        version: '1',
 			}))
 			.pipe(through2.obj(function(file) {
-				assert.equal(path.basename(file.path), 'fixture-1d229271.txt');
+				assert.equal(path.basename(file.path), 'fixture-1914dcfd.txt');
 				done();
 			}));
 	});
+
+  it('should change the hash using given version (integer)', function(done) {
+    gulp.src(__dirname + '/fixture.txt')
+      .pipe(hash({
+        algorithm: 'sha1',
+        hashLength: 8,
+        version: 1,
+      }))
+      .pipe(through2.obj(function(file) {
+        assert.equal(path.basename(file.path), 'fixture-1914dcfd.txt');
+        done();
+      }));
+  });
 
 	it('should append the hash to files with stream content', function(done) {
 		gulp.src(__dirname + '/fixture.txt', {buffer: false})
@@ -30,6 +44,18 @@ describe('hash()', function() {
 				done();
 			}));
 	});
+
+  it('should append the hash to files with buffer content', function(done) {
+    gulp.src(__dirname + '/fixture.txt', {buffer: true})
+      .pipe(hash({
+        algorithm: 'sha1',
+        hashLength: 8
+      }))
+      .pipe(through2.obj(function(file) {
+        assert.equal(path.basename(file.path), 'fixture-1d229271.txt');
+        done();
+      }));
+  });
 
 	it('should retain buffer file content', function(done) {
 		fs.readFile(__dirname + '/fixture.txt', {encoding: 'utf8'}, function(err, ref) {


### PR DESCRIPTION
If we pass an integer as the version, we'll see the type error:
```
TypeError: Not a string or buffer
    at TypeError (native)
    at Hash.update (crypto.js:70:16)
    at DestroyableTransform.<anonymous> (/Users/outpunk/Code/project/front/node_modules/gulp-hash/index.js:36:40)
    at DestroyableTransform.<anonymous> (/Users/outpunk/Code/project/front/node_modules/readable-stream/lib/_stream_transform.js:123:12)
```