### PR TITLE
Allow changing directory of output file

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ var exportObj = function(options) {
 				if (options.version !== '') hasher.update(String(options.version));
 				file.hash = hasher.digest('hex').slice(0, options.hashLength);
 
-				file.origFilename = path.basename(file.relative);
+				file.origPath = file.relative;
 				file.path = path.join(path.dirname(file.path), template(options.template, {
 					hash: file.hash,
 					name: fileName,
@@ -81,8 +81,8 @@ exportObj.manifest = function(manifestPath, append, space) {
 
 	return through2.obj(
 		function(file, enc, cb) {
-			if (typeof file.origFilename !== 'undefined') {
-				var manifestSrc = formatManifestPath(path.join(path.dirname(file.relative), file.origFilename));
+			if (typeof file.origPath !== 'undefined') {
+				var manifestSrc = formatManifestPath(file.origPath);
 				var manifestDest = formatManifestPath(file.relative);
 				manifest[manifestSrc] = manifestDest;
 			}

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -21,27 +21,46 @@ describe('hash.manifest()', function() {
 			}));
 	});
 
+	it('should support changing output paths', function(done) {
+		gulp.src(__dirname + '/fixture.txt')
+			.pipe(hash({
+				algorithm: 'sha1',
+				hashLength: 8,
+				template: 'out/<%= name %>-<%= hash %><%= ext %>'
+			}))
+			.pipe(hash.manifest(''))
+			.pipe(through2.obj(function(file) {
+				var err = null;
+				try {
+					assert.equal(file.contents.toString(), JSON.stringify({
+						"fixture.txt": "out/fixture-1d229271.txt"
+					}));
+				} catch(e) { err = e; }
+				done(err);
+			}));
+	});
+
 	it('the append option should work and use a queue', function(done) {
 		var fakeFile = new gutil.File({
 			contents: new Buffer('Hello'),
 			path: 'file-f7ff9e8b.txt'
 		});
 
-		fakeFile.origFilename = 'file.txt';
+		fakeFile.origPath = 'file.txt';
 
 		var fakeFile2 = new gutil.File({
 			contents: new Buffer('Hello'),
 			path: 'foo-123.txt'
 		});
 
-		fakeFile2.origFilename = 'foo.txt';
+		fakeFile2.origPath = 'foo.txt';
 
 		var fakeFile3 = new gutil.File({
 			contents: new Buffer('Hello'),
 			path: 'foo-456.txt'
 		});
 
-		fakeFile3.origFilename = 'foo.txt';
+		fakeFile3.origPath = 'foo.txt';
 
 		// First this sets manifest content to {"file.txt":"file-f7ff9e8b.txt"}
 		var manifestStream = hash.manifest('a', true);


### PR DESCRIPTION
This change makes sure the manifest file contains the original file path instead of taking the directory from the output file. This allows using gulp-rename or even adding a path in the output template to change the directory for the output files.