### PR TITLE
"Delete old output files if original files were changed" functionality was added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ var hash = require('gulp-hash');
 gulp.src('./js/**/*.js')
 	.pipe(hash()) // Add hashes to the files' names
 	.pipe(gulp.dest('public/js')) // Write the renamed files
-	.pipe(hash.manifest('assets.json')) // Switch to the manifest file
+	.pipe(hash.manifest('assets.json', {
+	  deleteOld: true,
+	  sourceDir: __dirname + '/public/js'
+	})) // Switch to the manifest file
 	.pipe(gulp.dest('public')); // Write the manifest file
 ```
 
@@ -30,13 +33,29 @@ The plugin fully supports both buffers and streams. If you encounter any problem
 | template | `'<%= name %>-<%= hash %><%= ext %>'` | The template used when adding the hash |
 | version | '' | A key to change the files' hashes without actually changing their content; appended to the contents when hashing |
 
-### hash.manifest(manifestPath, append, space)
+### hash.manifest(manifestPath, append, space) - option 1
 
 | Parameter | Default | Description |
 | --------- | ------- | ----------- |
 | manifestPath | (none) | The desired path to the manifest file |
 | append | true | (optional) Whether to merge the new manifest with an existing one's contents (same filename, doesn't have to exist before first run) |
 | space | undefined | (optional) [The space parameter for JSON.stringify()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)|
+
+[npm-url]: https://www.npmjs.org/package/gulp-hash
+[npm-image]: https://badge.fury.io/js/gulp-hash.svg
+
+[travis-url]: https://travis-ci.org/Dragory/gulp-hash
+[travis-image]: https://api.travis-ci.org/Dragory/gulp-hash.svg
+
+### hash.manifest(manifestPath, options) - option 2
+
+| Parameter | Default | Description |
+| --------- | ------- | ----------- |
+| manifestPath | (none) | The desired path to the manifest file |
+| options.append | true | (optional) Whether to merge the new manifest with an existing one's contents (same filename, doesn't have to exist before first run) |
+| options.space | undefined | (optional) [The space parameter for JSON.stringify()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)|
+| options.deleteOld | false | Delete old hashed file is original file is changed |
+| options.sourceDir | undefined | Path to output directory of hashed files. Is used if ```deleteOld``` parameter is set to ```true```
 
 [npm-url]: https://www.npmjs.org/package/gulp-hash
 [npm-image]: https://badge.fury.io/js/gulp-hash.svg

--- a/index.js
+++ b/index.js
@@ -8,54 +8,54 @@ var crypto = require('crypto'),
     fs = require('fs');
 
 var exportObj = function(options) {
-	options = assign({}, {
-		algorithm: 'sha1',
-		hashLength: 8,
-		template: '<%= name %>-<%= hash %><%= ext %>',
-		version: ''
-	}, options);
+  options = assign({}, {
+    algorithm: 'sha1',
+    hashLength: 8,
+    template: '<%= name %>-<%= hash %><%= ext %>',
+    version: ''
+  }, options);
 
-	return through2.obj(function(file, enc, cb) {
-		if (file.isDirectory()) {
-			this.push(file);
-			cb();
-			return;
-		}
+  return through2.obj(function(file, enc, cb) {
+    if (file.isDirectory()) {
+      this.push(file);
+      cb();
+      return;
+    }
 
-		var fileExt = path.extname(file.relative),
-		    fileName = path.basename(file.relative, fileExt);
+    var fileExt = path.extname(file.relative),
+        fileName = path.basename(file.relative, fileExt);
 
-		var hasher = crypto.createHash(options.algorithm);
+    var hasher = crypto.createHash(options.algorithm);
 
-		var piped = file.pipe(through2(
-			function(chunk, enc, updateCb) {
-				hasher.update(chunk);
-				updateCb(null, chunk);
-			},
+    var piped = file.pipe(through2(
+      function(chunk, enc, updateCb) {
+        hasher.update(chunk);
+        updateCb(null, chunk);
+      },
 
-			function(flushCb) {
-				if (options.version !== '') hasher.update(String(options.version));
-				file.hash = hasher.digest('hex').slice(0, options.hashLength);
+      function(flushCb) {
+        if (options.version !== '') hasher.update(String(options.version));
+        file.hash = hasher.digest('hex').slice(0, options.hashLength);
 
-				file.origPath = file.relative;
-				file.path = path.join(path.dirname(file.path), template(options.template, {
-					hash: file.hash,
-					name: fileName,
-					ext: fileExt
-				}));
+        file.origPath = file.relative;
+        file.path = path.join(path.dirname(file.path), template(options.template, {
+          hash: file.hash,
+          name: fileName,
+          ext: fileExt
+        }));
 
-				this.push(file);
-				cb();
-				flushCb();
-			}.bind(this)
-		));
+        this.push(file);
+        cb();
+        flushCb();
+      }.bind(this)
+    ));
 
-		if (file.isStream()) {
-			var newContents = through2();
-			piped.pipe(newContents);
-			file.contents = newContents;
-		}
-	});
+    if (file.isStream()) {
+      var newContents = through2();
+      piped.pipe(newContents);
+      file.contents = newContents;
+    }
+  });
 };
 
 var origManifestContents = {};
@@ -63,55 +63,84 @@ var appendQueue = Promise.resolve();
 
 // Normalizes a path for the manifest file (i.e. backslashes -> slashes)
 function formatManifestPath(mPath) {
-	return path.normalize(mPath).replace(/\\/g, '/');
+  return path.normalize(mPath).replace(/\\/g, '/');
 }
 
-exportObj.manifest = function(manifestPath, append, space) {
-	append = (typeof append === 'undefined' ? true : append);
-	var manifest = {};
+exportObj.manifest = function(manifestPath, options) {
+  var space;
+  var append;
+  var sourceDir;
+  var deleteOld = false;
 
-	if (append && ! origManifestContents[manifestPath]) {
-		try {
-			var content = fs.readFileSync(manifestPath, {encoding: 'utf8'});
-			origManifestContents[manifestPath] = JSON.parse(content);
-		} catch (e) {
-			origManifestContents[manifestPath] = {};
-		}
-	}
+  if (arguments.length === 2 && typeof options === 'object') {
+    append = options.append;
+    space = options.space;
+    sourceDir = options.sourceDir;
+    deleteOld = !!options.deleteOld;
+  }
 
-	return through2.obj(
-		function(file, enc, cb) {
-			if (typeof file.origPath !== 'undefined') {
-				var manifestSrc = formatManifestPath(file.origPath);
-				var manifestDest = formatManifestPath(file.relative);
-				manifest[manifestSrc] = manifestDest;
-			}
+  append = (typeof append === 'undefined' ? true : !!append);
 
-			cb();
-		},
+  var manifest = {};
 
-		function(cb) {
-			var finish = function(data) {
-				origManifestContents[manifestPath] = data;
+  if (append && ! origManifestContents[manifestPath]) {
+    try {
+      var content = fs.readFileSync(manifestPath, {encoding: 'utf8'});
+      origManifestContents[manifestPath] = JSON.parse(content);
+    } catch (e) {
+      origManifestContents[manifestPath] = {};
+    }
+  }
 
-				this.push(new gutil.File({
-					path: manifestPath,
-					contents: new Buffer(JSON.stringify(origManifestContents[manifestPath], undefined, space))
-				}));
+  function deleteOldFiles(oldfiles, newFiles, dirPath) {
+    for (var prop in oldfiles) {
+      if (newFiles.hasOwnProperty(prop) === false || oldfiles[prop] !== newFiles[prop]) {
+        try {
+          fs.unlinkSync(dirPath + '/' + oldfiles[prop]);
+        } catch (e) {
+          console.warn(e.message);
+        }
+      }
+    }
+  }
 
-				cb();
-			}.bind(this);
+  return through2.obj(
+    function(file, enc, cb) {
+      if (typeof file.origPath !== 'undefined') {
+        var manifestSrc = formatManifestPath(file.origPath);
+        var manifestDest = formatManifestPath(file.relative);
+        manifest[manifestSrc] = manifestDest;
+      }
 
-			if (append) {
-				appendQueue.then(new Promise(function(resolve) {
-					finish(assign({}, origManifestContents[manifestPath], manifest));
-					resolve();
-				}));
-			} else {
-				finish(manifest);
-			}
-		}
-	);
+      cb();
+    },
+
+    function(cb) {
+      var finish = function(data) {
+        if (deleteOld) {
+          deleteOldFiles(origManifestContents[manifestPath], data, sourceDir);
+        }
+
+        origManifestContents[manifestPath] = data;
+
+        this.push(new gutil.File({
+          path: manifestPath,
+          contents: new Buffer(JSON.stringify(origManifestContents[manifestPath], undefined, space))
+        }));
+
+        cb();
+      }.bind(this);
+
+      if (append) {
+        appendQueue.then(new Promise(function(resolve) {
+          finish(assign({}, origManifestContents[manifestPath], manifest));
+          resolve();
+        }));
+      } else {
+        finish(manifest);
+      }
+    }
+  );
 };
 
 module.exports = exportObj;

--- a/index.js
+++ b/index.js
@@ -92,11 +92,11 @@ exportObj.manifest = function(manifestPath, options) {
     }
   }
 
-  function deleteOldFiles(oldfiles, newFiles, dirPath) {
-    for (var prop in oldfiles) {
-      if (newFiles.hasOwnProperty(prop) === false || oldfiles[prop] !== newFiles[prop]) {
+  function deleteOldFiles(oldFiles, newFiles, dirPath) {
+    for (var prop in oldFiles) {
+      if (newFiles.hasOwnProperty(prop) === false || oldFiles[prop] !== newFiles[prop]) {
         try {
-          fs.unlinkSync(dirPath + '/' + oldfiles[prop]);
+          fs.unlinkSync(dirPath + '/' + oldFiles[prop]);
         } catch (e) {
           console.warn(e.message);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gulp-hash",
-  "version": "4.0.1",
+  "name": "gulp-hash-cleanup",
+  "version": "1.0.0",
   "description": "Cachebust your assets by adding a hash to the filename",
   "license": "MIT",
   "keywords": [
@@ -10,8 +10,8 @@
     "gulpplugin"
   ],
   "author": {
-    "name": "Miikka Virtanen",
-    "email": "contact@mivir.fi"
+    "name": "Ihor Omelchenko",
+    "email": "megapixel23@gmail.com"
   },
   "contributors": [
     {
@@ -30,7 +30,7 @@
       "name": "https://github.com/outpunk"
     }
   ],
-  "homepage": "https://github.com/Dragory/gulp-hash",
+  "homepage": "https://github.com/MEGApixel23/gulp-hash",
   "repository": {
     "type": "git",
     "url": "git@github.com:Dragory/gulp-hash.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gulp-hash-cleanup",
-  "version": "1.0.0",
+  "name": "gulp-hash",
+  "version": "4.0.2",
   "description": "Cachebust your assets by adding a hash to the filename",
   "license": "MIT",
   "keywords": [
@@ -10,8 +10,8 @@
     "gulpplugin"
   ],
   "author": {
-    "name": "Ihor Omelchenko",
-    "email": "megapixel23@gmail.com"
+    "name": "Miikka Virtanen",
+    "email": "contact@mivir.fi"
   },
   "contributors": [
     {
@@ -30,7 +30,7 @@
       "name": "https://github.com/outpunk"
     }
   ],
-  "homepage": "https://github.com/MEGApixel23/gulp-hash",
+  "homepage": "https://github.com/Dragory/gulp-hash",
   "repository": {
     "type": "git",
     "url": "git@github.com:Dragory/gulp-hash.git"

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -3,7 +3,8 @@ var path = require('path'),
 	gutil = require('gulp-util'),
 	through2 = require('through2'),
 	assert = require('assert'),
-	hash = require('../index.js');
+	hash = require('../index.js'),
+	fs = require('fs');
 
 describe('hash.manifest()', function() {
 	it('should generate valid manifest file', function(done) {
@@ -90,4 +91,51 @@ describe('hash.manifest()', function() {
 		stream3.write(fakeFile3);
 		stream3.end();
 	});
+
+	it('should delete old processed filed if original file was changed', function(done) {
+    var originalContent = 'Original content';
+    var changedContent = 'Changed content';
+		var outputDirPath = __dirname + '/temp';
+		var filePath = outputDirPath + '/test_file.txt';
+		var firstOutputPath = outputDirPath + '/test_file-b9d5922c.txt';
+		var secondOutputPath = outputDirPath + '/test_file-93d79001.txt';
+
+		var cleanup = function() {
+      fs.existsSync(firstOutputPath) && fs.unlinkSync(firstOutputPath);
+      fs.existsSync(secondOutputPath) && fs.unlinkSync(secondOutputPath);
+      fs.existsSync(filePath) && fs.unlinkSync(filePath);
+		};
+
+    cleanup();
+
+    fs.writeFileSync(filePath, originalContent);
+
+    gulp.src(filePath)
+      .pipe(hash())
+      .pipe(gulp.dest(outputDirPath))
+      .pipe(hash.manifest('a'))
+
+      .pipe(through2.obj(function() {
+        fs.writeFileSync(filePath, changedContent);
+
+        gulp.src(filePath)
+          .pipe(hash())
+        	.pipe(gulp.dest(outputDirPath))
+          .pipe(hash.manifest('a', {
+          	deleteOld: true,
+            sourceDir: (outputDirPath)
+					}))
+          .pipe(through2.obj(function() {
+            var err = null;
+
+            try {
+              assert.equal(fs.existsSync(firstOutputPath), false, 'First file should be delete');
+              assert.equal(fs.readFileSync(secondOutputPath), changedContent, 'Second file should have correct content');
+            } catch (e) { err = e; }
+
+            cleanup();
+            done(err);
+          }));
+      }));
+	})
 });

--- a/test/temp/.gitignore
+++ b/test/temp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
In a current version of this package if there is original file ```app.js``` and a user runs gulp task it will generate an output file (e.g. ```app-111111.js```). If a content of original file ```app.js``` is changed and gulp task is run again different output file (e.g. ```app-222222.js```) and the old one will exist as well.

This pull request adds functionality that helps to keep only one version of an output file and deletes old unneeded versions if they are redundant. A new version of a package supports old signature and provides backward compatibility for existing usage of ```hash.manifest()``` method.

Basic usage of a new function:
```javascript
hash.manifest('manifest.json', {
  deleteOld: true,
  sourceDir: __dirname + '/public/js'
});
```