### PR TITLE
Fix gulp-util deprecation

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,6 @@ var exportObj = function(options) {
 			file.contents.pipe(newContents);
 			file.contents = newContents;
 		} else if (file.isBuffer()) {
-			//console.dir(file);
 			stream.end(file.contents);
 		} else {
 			stream.end();

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
   "main": "./index.js",
   "dependencies": {
     "es6-promise": "^2.1.1",
-    "gulp-util": "^2.2.17",
     "lodash.assign": "^2.4.1",
     "lodash.template": "^2.4.1",
-    "through2": "^2.0.0"
+    "through2": "^2.0.0",
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0",

--- a/test/algorithms.js
+++ b/test/algorithms.js
@@ -1,7 +1,6 @@
 var path = require('path'),
     fs = require('fs'),
     gulp = require('gulp'),
-    gutil = require('gulp-util'),
 	assert = require('assert'),
 	through2 = require('through2'),
 	hash = require('../index.js');

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -1,6 +1,6 @@
 var path = require('path'),
     gulp = require('gulp'),
-	gutil = require('gulp-util'),
+		Vinyl = require('vinyl'),
 	through2 = require('through2'),
 	assert = require('assert'),
 	hash = require('../index.js'),
@@ -48,21 +48,21 @@ describe('hash.manifest()', function() {
 	it('the append option should work and use a queue', function(done) {
 		hash.resetManifestCache();
 
-		var fakeFile = new gutil.File({
+		var fakeFile = new Vinyl({
 			contents: new Buffer('Hello'),
 			path: 'file-f7ff9e8b.txt'
 		});
 
 		fakeFile.origPath = 'file.txt';
 
-		var fakeFile2 = new gutil.File({
+		var fakeFile2 = new Vinyl({
 			contents: new Buffer('Hello'),
 			path: 'foo-123.txt'
 		});
 
 		fakeFile2.origPath = 'foo.txt';
 
-		var fakeFile3 = new gutil.File({
+		var fakeFile3 = new Vinyl({
 			contents: new Buffer('Hello'),
 			path: 'foo-456.txt'
 		});


### PR DESCRIPTION
Based on https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5 I replaced gulp-util with Vinyl. Also Vinyl removed pipe() method https://github.com/gulpjs/vinyl/issues/107.