### PR TITLE
Added "dummyHash" option. If set to true, generated hashes will alway…

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ var exportObj = function(options) {
 		algorithm: 'sha1',
 		hashLength: 8,
 		template: '<%= name %>-<%= hash %><%= ext %>',
-		version: ''
+		version: '',
+		dummyHash: false
 	}, options);
 
 	return through2.obj(function(file, enc, cb) {
@@ -35,8 +36,8 @@ var exportObj = function(options) {
 			},
 
 			function(flushCb) {
-				if (options.version !== '') hasher.update(String(options.version));
-				file.hash = hasher.digest('hex').slice(0, options.hashLength);
+				if (options.version !== '' && !options.dummyHash) hasher.update(String(options.version));
+				file.hash = (options.dummyHash) ? '0'.repeat(options.hashLength) : hasher.digest('hex').slice(0, options.hashLength);
 
 				file.origPath = file.relative;
 				file.path = path.join(path.dirname(file.path), template(options.template, {


### PR DESCRIPTION
…s be a string of 0s regardless of actual file contents (length will be as specified with the hashLength option).

Why?
When developing, it's useful to be able to force the hash to a known value (so you can get deterministic file names). This makes it possible, for example, to use browserSync.stream() on css assets without having to completely disable the asset hashing and manifest code in your dev build scripts (thus helping keep your dev scripts as close to your production ones as possible).