### PR TITLE
Map function to allow custom manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The plugin fully supports both buffers and streams. If you encounter any problem
 | options.space | null | [The space parameter for JSON.stringify()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)|
 | options.deleteOld | false | If set to `true`, deletes old versions of hashed files |
 | options.sourceDir | __dirname | Used with `deleteOld`. Specifies where to search for old files to delete. |
+| options.map | (none) | Function allowing to modify keys (source) and values (destination) before the creation of the manifest. Should return an array with the new key-value pair respectively in the first and second entry. |
 
 ### hash.manifest(manifestPath, append, space)
 

--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ exportObj.manifest = function(manifestPath, options) {
 
 				this.push(new Vinyl({
 					path: manifestPath,
-					contents: new Buffer(JSON.stringify(origManifestContents[manifestPath], undefined, space))
+					contents: Buffer.from(JSON.stringify(origManifestContents[manifestPath], undefined, space))
 				}));
 
 				cb();

--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ exportObj.manifest = function(manifestPath, options) {
 	var space = null;
 	var append = true;
 	var sourceDir = __dirname;
+	var map = null;
 	var deleteOld = false;
 
 	if (arguments.length === 2 && typeof options === 'object') {
@@ -82,6 +83,7 @@ exportObj.manifest = function(manifestPath, options) {
 		if (options.append != null) append = options.append;
 		if (options.space != null) space = options.space;
 		if (options.sourceDir) sourceDir = options.sourceDir;
+		if (options.map) map = options.map;
 		deleteOld = !!options.deleteOld;
 	} else {
 		// Old signature
@@ -115,8 +117,9 @@ exportObj.manifest = function(manifestPath, options) {
 	return through2.obj(
 		function(file, enc, cb) {
 			if (typeof file.origPath !== 'undefined') {
-				var manifestSrc = formatManifestPath(file.origPath);
-				var manifestDest = formatManifestPath(file.relative);
+				var mapped = typeof map === 'function' ? map(file.origPath, file.relative) || [] : [];
+				var manifestSrc = formatManifestPath(mapped[0] || file.origPath);
+				var manifestDest = formatManifestPath(mapped[1] || file.relative);
 				newManifest[manifestSrc] = manifestDest;
 			}
 

--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ exportObj.manifest = function(manifestPath, options) {
 
 				this.push(new Vinyl({
 					path: manifestPath,
-					contents: Buffer.from(JSON.stringify(origManifestContents[manifestPath], undefined, space))
+					contents: new Buffer(JSON.stringify(origManifestContents[manifestPath], undefined, space))
 				}));
 
 				cb();


### PR DESCRIPTION
Hi, would be nice to have a function allowing custom manifest. This pull request, allows it.

Example :
```javascript
return gulp.src([
  './base.css'
])
.pipe(hash({
  hashLength: 8,
  template: '<%= hash %><%= ext %>'
}))
.pipe(gulp.dest('./dist'))
.pipe(hash.manifest('./data/assets.json', {
  map: function (origPath, relative) {
    return [origPath, '/css/' + relative];
  }
}))
.pipe(gulp.dest('.'));
```

Will produce :
`{"base.css":"/css/65c3ac6b.css"}` instead of `{"base.css":"65c3ac6b.css"}`

I also change the way buffer is created in a second commit, but looks like this commit doesn't pass checks, could remove it if need it.