### PR TITLE
Removing lodash.template depency as per the component Governance Alert

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var crypto = require('crypto'),
     through2 = require('through2'),
     Vinyl = require('vinyl'),
     assign = require('lodash.assign'),
-    template = require('lodash.template'),
+    _ = require('lodash'),
     path = require('path'),
     Promise = require('es6-promise').Promise,
     fs = require('fs');
@@ -39,7 +39,7 @@ var exportObj = function(options) {
 				file.hash = hasher.digest('hex').slice(0, options.hashLength);
 
 				file.origPath = file.relative;
-				file.path = path.join(path.dirname(file.path), template(options.template, {
+				file.path = path.join(path.dirname(file.path), _.template(options.template)({
 					hash: file.hash,
 					name: fileName,
 					ext: fileExt

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "es6-promise": "^2.1.1",
     "lodash.assign": "^2.4.1",
-    "lodash.template": "^2.4.1",
+    "lodash": "^4.17.21",
     "through2": "^2.0.0",
     "vinyl": "^2.1.0"
   },


### PR DESCRIPTION
As per the component governance alert made changes to remove lodash.template and replace with lodash. Made the fix as per the  suggestion provided in below link.

https://github.com/lodash/lodash/issues/5851

_"If you are using lodash.template directly in a project, to remove this alert you should install the latest version of lodash and use the template method off the main Lodash module instead, if you can't use another approach entirely."_